### PR TITLE
fix TypeError on passing case_insensitive to Bot init

### DIFF
--- a/stoat/ext/commands/core.py
+++ b/stoat/ext/commands/core.py
@@ -1175,7 +1175,7 @@ class GroupMixin(typing.Generic[GearT]):
     # )
 
     def __init__(self, /, *args: typing.Any, **kwargs: typing.Any) -> None:
-        case_insensitive = kwargs.get('case_insensitive', False)
+        case_insensitive = kwargs.pop('case_insensitive', False)
         self.all_commands: dict[str, Command[GearT, ..., typing.Any]] = (
             _CaseInsensitiveDict() if case_insensitive else {}
         )


### PR DESCRIPTION
The following code:
```py
from stoat.ext.commands import Bot

bot = Bot("?", case_insensitive=True)
```
Produces the following error:
```
Traceback (most recent call last):
  File "/home/thebe/python/testing/stoat_repro.py", line 3, in <module>
    bot = Bot("?", case_insensitive=False)
  File "/home/thebe/python/testing/.venv/lib/python3.14/site-packages/stoat/ext/commands/bot.py", line 211, in __init__
    GroupMixin.__init__(self, case_insensitive=case_insensitive)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thebe/python/testing/.venv/lib/python3.14/site-packages/stoat/ext/commands/core.py", line 1183, in __init__
    super().__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
TypeError: object.__init__() takes exactly one argument (the instance to initialize)
```

The change in this PR gets rid of this error, but passing `*args` and `**kwargs` to `object.__init__` just to ensure that they're empty seems like it might not be what you're meaning to do?