### PR TITLE
fix(http): pass payload to edit_server_category request

### DIFF
--- a/stoat/http.py
+++ b/stoat/http.py
@@ -6035,6 +6035,7 @@ class HTTPClient:
                 server_id=resolve_id(server),
                 category_id=resolve_id(category),
             ),
+            json=payload,
             http_overrides=http_overrides,
         )
         return self.state.parser.parse_category(resp)


### PR DESCRIPTION
The `json=payload` was not passed to the `request()` call in `edit_server_category`, 
causing the API to receive an empty body and return a 404.